### PR TITLE
feat: integrate Tracy profiling across engine and gfx backends

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -61,6 +61,10 @@ xmake r -g test/* # for all groups
 
 To build only a specific target group: `xmake build -g test/math`, `xmake build -g test/gfx`, etc.
 
+### Test Artifacts
+
+Save any test artifacts generated during agent runs under ./temp.
+
 ## Architecture Overview
 
 ### Module System
@@ -154,3 +158,4 @@ int main() {
 - Vulkan backend works on Windows and Linux (Wayland).
 - Runtime is set to `MD`/`MDd` (dynamic CRT) on Windows.
 - Source files use UTF-8 encoding (`set_encodings("utf-8")`).
+

--- a/hitagi/asset/material_parser.cpp
+++ b/hitagi/asset/material_parser.cpp
@@ -82,12 +82,16 @@ auto MaterialJSONParser::Parse(const core::Buffer& buffer) -> std::shared_ptr<Ma
         desc.pipeline.assembly_state.primitive = json.at("pipeline").value("primitive", gfx::PrimitiveTopology::TriangleList);
         if (bool enable_depth_test = json.at("pipeline").value("depth_test", true);
             enable_depth_test) {
-            desc.pipeline.depth_stencil_format                  = gfx::Format::D32_FLOAT;
-            desc.pipeline.depth_stencil_state.depth_test_enable = true;
+            desc.pipeline.depth_stencil_format                   = gfx::Format::D32_FLOAT;
+            desc.pipeline.depth_stencil_state.depth_test_enable  = true;
+            desc.pipeline.depth_stencil_state.depth_write_enable = true;
             desc.pipeline.rasterization_state =
                 {
                     .cull_mode = gfx::CullMode::Back,
                 };
+        }
+        if (json.at("pipeline").value("double_sided", false)) {
+            desc.pipeline.rasterization_state.cull_mode = gfx::CullMode::None;
         }
 
         if (json.contains("parameters")) {
@@ -130,6 +134,8 @@ auto MaterialJSONParser::Parse(const core::Buffer& buffer) -> std::shared_ptr<Ma
                 else if (type == "texture") {
                     if (param.contains("default"))
                         mat_param.value = std::make_shared<Texture>(param["default"]);
+                    else
+                        mat_param.value = std::shared_ptr<Texture>{};
                 } else {
                     logger->error("Unkown parameter type: {}", param["type"].get<std::string>());
                     return nullptr;

--- a/hitagi/core/file_io_manager.cppm
+++ b/hitagi/core/file_io_manager.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <tracy/Tracy.hpp>
+
 export module core:file_io_manager;
 import std;
 import :runtime_module;
@@ -24,7 +28,7 @@ private:
 
     using PathHash = std::size_t;
 
-    std::mutex                                                         m_CacheMutex;
+    TracyLockableN(std::mutex, m_CacheMutex, "FileIO Cache Mutex");
     std::pmr::unordered_map<PathHash, std::filesystem::file_time_type> m_FileStateCache;
     std::pmr::unordered_map<PathHash, Buffer>                          m_FileCache;
     Buffer                                                             m_EmptyBuffer;

--- a/hitagi/core/memory_manager.cppm
+++ b/hitagi/core/memory_manager.cppm
@@ -1,5 +1,6 @@
 module;
 #include <spdlog/logger.h>
+#include <tracy/Tracy.hpp>
 
 export module core:memory_manager;
 import std;
@@ -63,7 +64,7 @@ private:
     };
 
     struct Pool {
-        std::mutex      mutex{};
+        TracyLockableN(std::mutex, mutex, "MemoryPool Mutex");
         std::list<Page> pages{};
         Block*          free_list       = nullptr;
         std::size_t     page_size       = 8_kB;

--- a/hitagi/core/thread_manager.cpp
+++ b/hitagi/core/thread_manager.cpp
@@ -1,5 +1,6 @@
 module;
 #include <spdlog/logger.h>
+#include <tracy/Tracy.hpp>
 
 module core;
 
@@ -7,9 +8,12 @@ namespace hitagi::core {
 
 ThreadManager::ThreadManager(std::uint8_t num_threads) : RuntimeModule("ThreadManager"), m_Stop(false) {
     m_Logger->trace("create thread pool({})", num_threads);
+    TracyPlotConfig("Thread Tasks Pending", tracy::PlotFormatType::Number, true, true, 0);
 
     for (std::uint8_t i = 0; i < num_threads; i++) {
-        m_ThreadPools.emplace_back([this] {
+        m_ThreadPools.emplace_back([this, i] {
+            const auto thread_name = std::format("Hitagi/Worker-{}", i);
+            tracy::SetThreadName(thread_name.c_str());
             while (true) {
                 std::packaged_task<void()> task;
                 {
@@ -19,6 +23,7 @@ ThreadManager::ThreadManager(std::uint8_t num_threads) : RuntimeModule("ThreadMa
                         return;
                     task = std::move(m_Tasks.front());
                     m_Tasks.pop();
+                    TracyPlot("Thread Tasks Pending", static_cast<std::int64_t>(m_Tasks.size()));
                 }
                 task();
             }

--- a/hitagi/core/thread_manager.cppm
+++ b/hitagi/core/thread_manager.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <tracy/Tracy.hpp>
+
 export module core:thread_manager;
 import std;
 import :runtime_module;
@@ -25,6 +29,8 @@ private:
     bool                    m_Stop;
 };
 
+auto CreateThreadManager(std::uint8_t num_threads = 8) -> std::unique_ptr<RuntimeModule>;
+
 template <typename Func, typename... Args>
 decltype(auto) ThreadManager::RunTask(Func&& func, Args&&... args) {
     using return_type = std::invoke_result_t<Func, Args...>;
@@ -37,10 +43,15 @@ decltype(auto) ThreadManager::RunTask(Func&& func, Args&&... args) {
     {
         std::unique_lock lock(m_QueueMutex);
         m_Tasks.emplace([task] { (*task)(); });
+        TracyPlot("Thread Tasks Pending", static_cast<std::int64_t>(m_Tasks.size()));
     }
 
     m_ConditionForTask.notify_one();
     return res;
+}
+
+inline auto CreateThreadManager(std::uint8_t num_threads) -> std::unique_ptr<RuntimeModule> {
+    return std::make_unique<ThreadManager>(num_threads);
 }
 
 }  // namespace hitagi::core

--- a/hitagi/ecs/schedule.cpp
+++ b/hitagi/ecs/schedule.cpp
@@ -1,6 +1,7 @@
 module;
 #include <taskflow/taskflow.hpp>
 #include <spdlog/logger.h>
+#include <tracy/Tracy.hpp>
 
 module ecs;
 import std;
@@ -42,7 +43,20 @@ void Schedule::Run(tf::Executor& executor) {
         direct_graph[i] = {};
 
     for (const auto& task : m_Tasks) {
-        tasks.emplace_back(taskflow.emplace([&]() { task->Run(world); }).name(task->name.data()));
+        tasks.emplace_back(taskflow.emplace([this, &executor, task]() {
+            thread_local bool tracy_thread_named = false;
+            if (!tracy_thread_named) {
+                if (const auto worker_id = executor.this_worker_id(); worker_id >= 0) {
+                    const auto thread_name = std::format("Hitagi/ECS/{}/Worker-{}", world.GetName(), worker_id);
+                    tracy::SetThreadName(thread_name.c_str());
+                    tracy_thread_named = true;
+                }
+            }
+
+            ZoneScoped;
+            ZoneName(task->name.data(), task->name.size());
+            task->Run(world);
+        }).name(task->name.data()));
     }
 
     for (const auto& [component, task_indices] : m_ReadBeforeWriteSet) {
@@ -97,6 +111,7 @@ void Schedule::Run(tf::Executor& executor) {
         return;
     }
 
+    ZoneScopedN("ECSFrame");
     executor.run(taskflow).wait();
 }
 

--- a/hitagi/ecs/world.cpp
+++ b/hitagi/ecs/world.cpp
@@ -1,5 +1,6 @@
 module;
 #include <spdlog/spdlog.h>
+#include <tracy/Tracy.hpp>
 
 module ecs;
 import std;
@@ -14,6 +15,7 @@ World::World(std::string_view name)
 }
 
 void World::Update() {
+    ZoneScopedN("ECS::World::Update");
     Schedule schedule(*this);
     m_SystemManager.Update(schedule);
     schedule.Run(m_Executor);

--- a/hitagi/ecs/world.cppm
+++ b/hitagi/ecs/world.cppm
@@ -16,6 +16,7 @@ public:
 
     void Update();
 
+    inline auto GetName() const noexcept -> std::string_view { return m_Name; }
     inline auto& GetEntityManager() noexcept { return m_EntityManager; }
     inline auto& GetSystemManager() noexcept { return m_SystemManager; }
     inline auto& GetEntityManager() const noexcept { return m_EntityManager; }

--- a/hitagi/engine/engine.cpp
+++ b/hitagi/engine/engine.cpp
@@ -26,13 +26,15 @@ public:
 };
 
 Engine::Engine(const std::filesystem::path& config_path) : RuntimeModule("Engine") {
+    tracy::SetThreadName("Hitagi/Main");
+
     auto add_inner_module = [&]<typename T>(std::unique_ptr<T> module) -> T* {
         return static_cast<T*>(RuntimeModule::AddSubModule(std::unique_ptr<RuntimeModule>{module.release()}));
     };
 
     add_inner_module(std::make_unique<core::MemoryManager>());
     add_inner_module(std::make_unique<core::FileIOManager>());
-    add_inner_module(std::make_unique<core::ThreadManager>());
+    add_inner_module(core::CreateThreadManager());
 
     // Input
     m_App = add_inner_module(Application::CreateApp(config_path));  // input manager is created here
@@ -56,6 +58,13 @@ void Engine::Tick() {
     ZoneScopedN("Engine");
     RuntimeModule::Tick();
     m_Clock.Tick();
+
+    static bool tracy_plot_configured = false;
+    if (!tracy_plot_configured) {
+        TracyPlotConfig("CPU Frame Time (ms)", tracy::PlotFormatType::Number, false, true, 0);
+        tracy_plot_configured = true;
+    }
+    TracyPlot("CPU Frame Time (ms)", m_Clock.DeltaTime().count() * 1000.0);
     FrameMark;
 }
 

--- a/hitagi/gfx/dx12/dx12_bindless.cpp
+++ b/hitagi/gfx/dx12/dx12_bindless.cpp
@@ -148,7 +148,6 @@ auto DX12BindlessUtils::CreateBindlessHandle(GPUBuffer& buffer, std::size_t inde
                 descriptor_increment_size));
     }
 
-    TracyAllocN((void*)handle.index, 1, "CBV_SRV_UAV_Bindless");
     return handle;
 }
 
@@ -204,7 +203,6 @@ auto DX12BindlessUtils::CreateBindlessHandle(Texture& texture, bool writable) ->
                 descriptor_increment_size));
     }
 
-    TracyAllocN((void*)handle.index, 1, "CBV_SRV_UAV_Bindless");
     return handle;
 }
 
@@ -230,7 +228,6 @@ auto DX12BindlessUtils::CreateBindlessHandle(Sampler& sampler) -> BindlessHandle
             handle.index,
             descriptor_increment_size));
 
-    TracyAllocN((void*)handle.index, 1, "Sampler_Bindless");
     return handle;
 }
 
@@ -239,12 +236,6 @@ void DX12BindlessUtils::DiscardBindlessHandle(BindlessHandle handle) {
 
     std::scoped_lock lock{m_Mutex};
     auto&            pool = handle.type == BindlessHandleType::Sampler ? m_Available_Sampler_BindlessHandlePool : m_Available_CBV_SRV_UAV_BindlessHandlePool;
-
-    if (handle.type == BindlessHandleType::Sampler) {
-        TracyFreeN((void*)handle.index, "Sampler_Bindless");
-    } else {
-        TracyFreeN((void*)handle.index, "CBV_SRV_UAV_Bindless");
-    }
 
     handle.type     = BindlessHandleType::Invalid;
     handle.writable = 0;

--- a/hitagi/gfx/dx12/dx12_bindless.cppm
+++ b/hitagi/gfx/dx12/dx12_bindless.cppm
@@ -1,6 +1,7 @@
 module;
 
 #include <d3d12.h>
+#include <tracy/Tracy.hpp>
 #include <wrl.h>
 
 export module gfx.dx12:bindless;
@@ -30,7 +31,7 @@ public:
     inline auto GetBindlessRootSignature() const noexcept { return m_RootSignature; }
 
 private:
-    std::mutex m_Mutex;
+    TracyLockableN(std::mutex, m_Mutex, "DX12 Bindless Mutex");
 
     ComPtr<ID3D12RootSignature> m_RootSignature;
 

--- a/hitagi/gfx/dx12/dx12_command_list.cpp
+++ b/hitagi/gfx/dx12/dx12_command_list.cpp
@@ -1,12 +1,15 @@
 module;
 
+#include <cstring>
 #include <spdlog/logger.h>
 #include <fmt/color.h>
 #include <d3dx12/d3dx12.h>
+#include <tracy/TracyD3D12.hpp>
 
 module gfx.dx12;
 import std;
 import :command_list;
+import :command_queue;
 import :utils;
 
 namespace hitagi::gfx {
@@ -102,10 +105,26 @@ void DX12GraphicsCommandList::Begin() {
     command_list->SetDescriptorHeaps(descriptor_heaps.size(), descriptor_heaps.data());
     command_list->SetGraphicsRootSignature(dx12_bindless_utils.GetBindlessRootSignature().Get());
 
+#ifdef TRACY_ENABLE
+    auto& queue = static_cast<DX12CommandQueue&>(m_Device.GetCommandQueue(CommandType::Graphics));
+    m_TracyZone = std::make_unique<tracy::D3D12ZoneScope>(
+        queue.GetTracyCtx(),
+        __LINE__,
+        __FILE__,
+        sizeof(__FILE__) - 1,
+        __FUNCTION__,
+        std::strlen(__FUNCTION__),
+        m_Name.data(),
+        m_Name.size(),
+        command_list.Get(),
+        true);
+#endif
+
     m_Pipeline = nullptr;
 }
 
 void DX12GraphicsCommandList::End() {
+    m_TracyZone.reset();
     command_list->Close();
 }
 
@@ -261,10 +280,26 @@ void DX12ComputeCommandList::Begin() {
     command_list->SetDescriptorHeaps(descriptor_heaps.size(), descriptor_heaps.data());
     command_list->SetComputeRootSignature(dx12_bindless_utils.GetBindlessRootSignature().Get());
 
+#ifdef TRACY_ENABLE
+    auto& queue = static_cast<DX12CommandQueue&>(m_Device.GetCommandQueue(CommandType::Compute));
+    m_TracyZone = std::make_unique<tracy::D3D12ZoneScope>(
+        queue.GetTracyCtx(),
+        __LINE__,
+        __FILE__,
+        sizeof(__FILE__) - 1,
+        __FUNCTION__,
+        std::strlen(__FUNCTION__),
+        m_Name.data(),
+        m_Name.size(),
+        command_list.Get(),
+        true);
+#endif
+
     m_Pipeline = nullptr;
 }
 
 void DX12ComputeCommandList::End() {
+    m_TracyZone.reset();
     command_list->Close();
 }
 
@@ -298,9 +333,24 @@ DX12CopyCommandList::DX12CopyCommandList(DX12Device& device, std::string_view na
 }
 
 void DX12CopyCommandList::Begin() {
+#ifdef TRACY_ENABLE
+    auto& queue = static_cast<DX12CommandQueue&>(m_Device.GetCommandQueue(CommandType::Copy));
+    m_TracyZone = std::make_unique<tracy::D3D12ZoneScope>(
+        queue.GetTracyCtx(),
+        __LINE__,
+        __FILE__,
+        sizeof(__FILE__) - 1,
+        __FUNCTION__,
+        std::strlen(__FUNCTION__),
+        m_Name.data(),
+        m_Name.size(),
+        command_list.Get(),
+        true);
+#endif
 }
 
 void DX12CopyCommandList::End() {
+    m_TracyZone.reset();
     command_list->Close();
 }
 

--- a/hitagi/gfx/dx12/dx12_command_list.cppm
+++ b/hitagi/gfx/dx12/dx12_command_list.cppm
@@ -1,5 +1,6 @@
 module;
 #include <d3d12.h>
+#include <tracy/TracyD3D12.hpp>
 #include <wrl.h>
 
 export module gfx.dx12:command_list;
@@ -60,6 +61,7 @@ public:
     ComPtr<ID3D12GraphicsCommandList> command_list;
     ComPtr<ID3D12CommandAllocator>    command_allocator;
     const RenderPipeline*             m_Pipeline = nullptr;
+    std::unique_ptr<tracy::D3D12ZoneScope> m_TracyZone;
 };
 
 class DX12ComputeCommandList : public ComputeCommandContext {
@@ -79,6 +81,7 @@ public:
     ComPtr<ID3D12GraphicsCommandList> command_list;
     ComPtr<ID3D12CommandAllocator>    command_allocator;
     const ComputePipeline*            m_Pipeline = nullptr;
+    std::unique_ptr<tracy::D3D12ZoneScope> m_TracyZone;
 };
 
 class DX12CopyCommandList : public CopyCommandContext {
@@ -120,6 +123,7 @@ public:
 
     ComPtr<ID3D12GraphicsCommandList> command_list;
     ComPtr<ID3D12CommandAllocator>    command_allocator;
+    std::unique_ptr<tracy::D3D12ZoneScope> m_TracyZone;
 };
 
 }  // namespace hitagi::gfx

--- a/hitagi/gfx/dx12/dx12_command_queue.cpp
+++ b/hitagi/gfx/dx12/dx12_command_queue.cpp
@@ -3,6 +3,7 @@ module;
 #include <spdlog/logger.h>
 #include <fmt/color.h>
 #include <d3dx12/d3dx12.h>
+#include <tracy/TracyD3D12.hpp>
 
 module gfx.dx12;
 import std;
@@ -31,6 +32,12 @@ DX12CommandQueue::DX12CommandQueue(DX12Device& device, CommandType type, std::st
         throw std::runtime_error(error_message);
     }
     m_Queue->SetName(std::wstring(name.begin(), name.end()).c_str());
+    m_TracyCtx = TracyD3D12Context(device.GetDevice().Get(), m_Queue.Get());
+    TracyD3D12ContextName(m_TracyCtx, m_Name.data(), static_cast<uint16_t>(m_Name.size()));
+}
+
+DX12CommandQueue::~DX12CommandQueue() {
+    TracyD3D12Destroy(m_TracyCtx);
 }
 
 void DX12CommandQueue::Submit(std::span<const std::reference_wrapper<const CommandContext>> contexts,
@@ -73,6 +80,7 @@ void DX12CommandQueue::Submit(std::span<const std::reference_wrapper<const Comma
 
     if (!command_lists.empty()) {
         m_Queue->ExecuteCommandLists(command_lists.size(), command_lists.data());
+        TracyD3D12Collect(m_TracyCtx);
     }
 
     for (const auto& signal_fence : signal_fences) {
@@ -85,6 +93,10 @@ void DX12CommandQueue::Submit(std::span<const std::reference_wrapper<const Comma
 void DX12CommandQueue::WaitIdle() {
     if (m_SubmitCount == 0) return;
     m_Fence.Wait(m_SubmitCount);
+}
+
+void DX12CommandQueue::NewFrame() {
+    TracyD3D12NewFrame(m_TracyCtx);
 }
 
 }  // namespace hitagi::gfx

--- a/hitagi/gfx/dx12/dx12_command_queue.cppm
+++ b/hitagi/gfx/dx12/dx12_command_queue.cppm
@@ -1,5 +1,6 @@
 module;
 #include <d3d12.h>
+#include <tracy/TracyD3D12.hpp>
 #include <wrl.h>
 
 export module gfx.dx12:command_queue;
@@ -16,6 +17,7 @@ class DX12Device;
 class DX12CommandQueue : public CommandQueue {
 public:
     DX12CommandQueue(DX12Device& device, CommandType type, std::string_view name);
+    ~DX12CommandQueue() override;
 
     void Submit(
         std::span<const std::reference_wrapper<const CommandContext>> contexts,
@@ -23,12 +25,15 @@ public:
         std::span<const FenceSignalInfo>                              signal_fences = {}) final;
 
     void WaitIdle() final;
+    void NewFrame();
 
     inline auto GetDX12Queue() const noexcept { return m_Queue; }
+    inline auto GetTracyCtx() const noexcept { return m_TracyCtx; }
 
 private:
     ComPtr<ID3D12CommandQueue> m_Queue;
     DX12Fence                  m_Fence;
     std::uint64_t              m_SubmitCount = 0;
+    TracyD3D12Ctx              m_TracyCtx    = nullptr;
 };
 }  // namespace hitagi::gfx

--- a/hitagi/gfx/dx12/dx12_device.cpp
+++ b/hitagi/gfx/dx12/dx12_device.cpp
@@ -203,13 +203,18 @@ DX12Device::~DX12Device() {
 
 void DX12Device::Tick() {
     Device::Tick();
+#ifdef TRACY_ENABLE
+    for (const auto& queue : m_CommandQueues) {
+        queue->NewFrame();
+    }
+#endif
     if (m_EnableProfile) {
         Profile();
     }
 }
 
 void DX12Device::WaitIdle() {
-    ZoneScopedN("DX12Device::WaitIdle");
+    ZoneScopedNS("DX12Device::WaitIdle", 8);
     for (auto& queue : m_CommandQueues) {
         queue->WaitIdle();
     }

--- a/hitagi/gfx/dx12/dx12_sync.cpp
+++ b/hitagi/gfx/dx12/dx12_sync.cpp
@@ -3,6 +3,7 @@ module;
 #include <spdlog/logger.h>
 #include <fmt/color.h>
 #include <d3dx12/d3dx12.h>
+#include <tracy/Tracy.hpp>
 
 module gfx.dx12;
 import :sync;
@@ -45,7 +46,7 @@ void DX12Fence::Signal(std::uint64_t value) {
 }
 
 bool DX12Fence::Wait(std::uint64_t value, std::chrono::milliseconds timeout) {
-    auto dx12_device = static_cast<DX12Device&>(m_Device).GetDevice();
+    ZoneScopedNS("DX12Fence::Wait", 8);
     if (m_Fence->GetCompletedValue() < value) {
         m_Fence->SetEventOnCompletion(value, m_EventHandle);
         return WAIT_TIMEOUT != WaitForSingleObject(m_EventHandle, timeout.count());

--- a/hitagi/gfx/gfx.cpp
+++ b/hitagi/gfx/gfx.cpp
@@ -48,6 +48,20 @@ auto readback_texture(Device& device, Texture& texture, TextureSubresourceLayer 
 
     device.WaitIdle();
 
+    if (texture.GetCurrentLayout() != TextureLayout::Common &&
+        texture.GetCurrentLayout() != TextureLayout::Unkown) {
+        auto gfx_ctx = device.CreateGraphicsContext("readback_transition");
+        gfx_ctx->Begin();
+        gfx_ctx->ResourceBarrier(
+            {}, {},
+            {{texture.Transition(BarrierAccess::None, TextureLayout::Common, PipelineStage::None)}});
+        gfx_ctx->End();
+
+        auto& gfx_queue = device.GetCommandQueue(CommandType::Graphics);
+        gfx_queue.Submit({{*gfx_ctx}});
+        gfx_queue.WaitIdle();
+    }
+
     auto ctx = device.CreateCopyContext("readback_copy");
     ctx->Begin();
     ctx->ResourceBarrier(

--- a/hitagi/gfx/render_graph/render_graph.cpp
+++ b/hitagi/gfx/render_graph/render_graph.cpp
@@ -335,6 +335,8 @@ bool RenderGraph::Compile() {
 
         if (num_visited_nodes != essential_nodes.size()) {
             m_Logger->error("RenderGraph has cycle");
+            const auto message = std::format("{} has cycle", m_Name);
+            TracyMessageCS(message.data(), message.size(), tracy::Color::Red3, 8);
             m_ExecuteLayers.clear();
             return false;
         }
@@ -354,6 +356,7 @@ auto RenderGraph::Execute() -> std::uint64_t {
 
     if (!m_Compiled) {
         m_Logger->warn("RenderGraph has not been compiled");
+        TracyMessageLCS("RenderGraph execute skipped because it is not compiled", tracy::Color::OrangeRed3, 8);
         return m_FrameIndex;
     }
 
@@ -400,6 +403,7 @@ auto RenderGraph::Execute() -> std::uint64_t {
     }
 
     RetireNodes();
+    Profile();
     Reset();
     return m_FrameIndex++;
 }
@@ -644,9 +648,15 @@ void RenderGraph::Profile() const noexcept {
     static bool configured = false;
     if (!configured) {
         TracyPlotConfig("Retired Resource Counts", tracy::PlotFormatType::Number, true, true, 0);
+        TracyPlotConfig("Transient Buffer Count", tracy::PlotFormatType::Number, true, true, 0);
+        TracyPlotConfig("Transient Texture Count", tracy::PlotFormatType::Number, true, true, 0);
+        TracyPlotConfig("RenderGraph Execute Layers", tracy::PlotFormatType::Number, true, true, 0);
         configured = true;
     }
     TracyPlot("Retired Resource Counts", static_cast<std::int64_t>(m_RetiredNodes.size()));
+    TracyPlot("Transient Buffer Count", static_cast<std::int64_t>(m_TransientPool.buffers.size()));
+    TracyPlot("Transient Texture Count", static_cast<std::int64_t>(m_TransientPool.textures.size()));
+    TracyPlot("RenderGraph Execute Layers", static_cast<std::int64_t>(m_ExecuteLayers.size()));
 }
 
 }  // namespace hitagi::rg

--- a/hitagi/gfx/render_graph/render_graph.cpp
+++ b/hitagi/gfx/render_graph/render_graph.cpp
@@ -324,7 +324,8 @@ bool RenderGraph::Compile() {
             for (auto node : start_nodes) {
                 num_visited_nodes++;
                 for (auto output_node : node->m_OutputNodes) {
-                    if (--in_degrees.at(output_node) == 0) {
+                    auto it = in_degrees.find(output_node);
+                    if (it != in_degrees.end() && --it->second == 0) {
                         new_start_nodes.emplace_back(output_node);
                     }
                 }

--- a/hitagi/gfx/vulkan/vk_bindless.cpp
+++ b/hitagi/gfx/vulkan/vk_bindless.cpp
@@ -10,13 +10,7 @@ import std;
 
 namespace hitagi::gfx {
 VulkanBindlessUtils::VulkanBindlessUtils(VulkanDevice& device, std::string_view name)
-    : BindlessUtils(device, name),
-      m_BindlessHandlePools{{
-          {{}, std::mutex{}},
-          {{}, std::mutex{}},
-          {{}, std::mutex{}},
-          {{}, std::mutex{}},
-      }} {
+    : BindlessUtils(device, name) {
     const auto logger = device.GetLogger();
 
     const auto limits = device.GetPhysicalDevice().getProperties().limits;
@@ -193,7 +187,6 @@ auto VulkanBindlessUtils::CreateBindlessHandle(GPUBuffer& buffer, std::uint64_t 
 
     vk_device.GetDevice().updateDescriptorSets(write_info, {});
 
-    TracyAllocN((void*)static_cast<std::uint64_t>(handle.index), 1, "GPUBuffer_bindless");
     return handle;
 }
 
@@ -251,12 +244,6 @@ auto VulkanBindlessUtils::CreateBindlessHandle(Texture& texture, bool writable) 
 
     vk_device.GetDevice().updateDescriptorSets(write_info, {});
 
-    if (writable) {
-        TracyAllocN((void*)static_cast<std::uint64_t>(handle.index), 1, "StorageTexture_bindless");
-    } else {
-        TracyAllocN((void*)static_cast<std::uint64_t>(handle.index), 1, "SampledTexture_bindless");
-    }
-
     return handle;
 }
 
@@ -287,8 +274,6 @@ auto VulkanBindlessUtils::CreateBindlessHandle(Sampler& sampler) -> BindlessHand
 
     vk_device.GetDevice().updateDescriptorSets(write_info, {});
 
-    TracyAllocN((void*)static_cast<std::uint64_t>(handle.index), 1, "Sampler_bindless");
-
     return handle;
 }
 
@@ -299,17 +284,13 @@ void VulkanBindlessUtils::DiscardBindlessHandle(BindlessHandle handle) {
 
     if (handle.type == BindlessHandleType::Buffer) {
         pool_index = 0;
-        TracyFreeN((void*)static_cast<std::uint64_t>(handle.index), "GPUBuffer_bindless");
     } else if (handle.type == BindlessHandleType::Texture) {
         if (handle.writable) {
             pool_index = 2;
-            TracyFreeN((void*)static_cast<std::uint64_t>(handle.index), "StorageTexture_bindless");
         } else {
             pool_index = 1;
-            TracyFreeN((void*)static_cast<std::uint64_t>(handle.index), "SampledTexture_bindless");
         }
     } else if (handle.type == BindlessHandleType::Sampler) {
-        TracyFreeN((void*)static_cast<std::uint64_t>(handle.index), "Sampler_bindless");
         pool_index = 3;
     } else {
         return;

--- a/hitagi/gfx/vulkan/vk_bindless.cppm
+++ b/hitagi/gfx/vulkan/vk_bindless.cppm
@@ -1,5 +1,6 @@
 module;
 
+#include <tracy/Tracy.hpp>
 #include <vulkan/vulkan_raii.hpp>
 
 export module gfx.vulkan:bindless;
@@ -27,7 +28,7 @@ struct VulkanBindlessUtils : public BindlessUtils {
 private:
     struct BindlessHandlePool {
         std::pmr::vector<BindlessHandle> pool;
-        std::mutex                       mutex{};
+        TracyLockableN(std::mutex, mutex, "Vulkan Bindless Pool Mutex");
     };
     std::array<BindlessHandlePool, 4> m_BindlessHandlePools{};
 };

--- a/hitagi/gfx/vulkan/vk_command_buffer.cpp
+++ b/hitagi/gfx/vulkan/vk_command_buffer.cpp
@@ -1,11 +1,14 @@
 module;
 
+#include <cstring>
 #include <spdlog/logger.h>
 #include <fmt/color.h>
 #include <vulkan/vulkan_raii.hpp>
+#include <tracy/TracyVulkan.hpp>
 
 module gfx.vulkan;
 import :command_buffer;
+import :command_queue;
 import std;
 import :resource;
 
@@ -117,9 +120,26 @@ void VulkanGraphicsCommandBuffer::Begin() {
         0,
         descriptor_sets,
         {});
+
+#ifdef TRACY_ENABLE
+    auto& queue = static_cast<VulkanCommandQueue&>(m_Device.GetCommandQueue(CommandType::Graphics));
+    m_TracyZone = std::make_unique<tracy::VkCtxScope>(
+        queue.GetTracyCtx(),
+        __LINE__,
+        __FILE__,
+        sizeof(__FILE__) - 1,
+        __FUNCTION__,
+        std::strlen(__FUNCTION__),
+        m_Name.data(),
+        m_Name.size(),
+        *command_buffer,
+        true);
+#endif
 }
 
 void VulkanGraphicsCommandBuffer::End() {
+    m_TracyZone.reset();
+    TracyVkCollect(static_cast<VulkanCommandQueue&>(m_Device.GetCommandQueue(CommandType::Graphics)).GetTracyCtx(), *command_buffer);
     command_buffer.end();
 }
 
@@ -334,9 +354,26 @@ void VulkanComputeCommandBuffer::Begin() {
         0,
         descriptor_sets,
         {});
+
+#ifdef TRACY_ENABLE
+    auto& queue = static_cast<VulkanCommandQueue&>(m_Device.GetCommandQueue(CommandType::Compute));
+    m_TracyZone = std::make_unique<tracy::VkCtxScope>(
+        queue.GetTracyCtx(),
+        __LINE__,
+        __FILE__,
+        sizeof(__FILE__) - 1,
+        __FUNCTION__,
+        std::strlen(__FUNCTION__),
+        m_Name.data(),
+        m_Name.size(),
+        *command_buffer,
+        true);
+#endif
 }
 
 void VulkanComputeCommandBuffer::End() {
+    m_TracyZone.reset();
+    TracyVkCollect(static_cast<VulkanCommandQueue&>(m_Device.GetCommandQueue(CommandType::Compute)).GetTracyCtx(), *command_buffer);
     command_buffer.end();
 }
 
@@ -374,9 +411,26 @@ void VulkanTransferCommandBuffer::Begin() {
     command_buffer.begin(vk::CommandBufferBeginInfo{
         .flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit,
     });
+
+#ifdef TRACY_ENABLE
+    auto& queue = static_cast<VulkanCommandQueue&>(m_Device.GetCommandQueue(CommandType::Copy));
+    m_TracyZone = std::make_unique<tracy::VkCtxScope>(
+        queue.GetTracyCtx(),
+        __LINE__,
+        __FILE__,
+        sizeof(__FILE__) - 1,
+        __FUNCTION__,
+        std::strlen(__FUNCTION__),
+        m_Name.data(),
+        m_Name.size(),
+        *command_buffer,
+        true);
+#endif
 }
 
 void VulkanTransferCommandBuffer::End() {
+    m_TracyZone.reset();
+    TracyVkCollect(static_cast<VulkanCommandQueue&>(m_Device.GetCommandQueue(CommandType::Copy)).GetTracyCtx(), *command_buffer);
     command_buffer.end();
 }
 

--- a/hitagi/gfx/vulkan/vk_command_buffer.cppm
+++ b/hitagi/gfx/vulkan/vk_command_buffer.cppm
@@ -1,6 +1,7 @@
 module;
 
 #include <vulkan/vulkan_raii.hpp>
+#include <tracy/TracyVulkan.hpp>
 
 export module gfx.vulkan:command_buffer;
 import gfx.base;
@@ -68,6 +69,7 @@ public:
 
 private:
     const VulkanRenderPipeline* m_Pipeline = nullptr;
+    std::unique_ptr<tracy::VkCtxScope> m_TracyZone;
 };
 
 class VulkanComputeCommandBuffer final : public ComputeCommandContext {
@@ -90,6 +92,7 @@ public:
 
 private:
     const VulkanComputePipeline* m_Pipeline = nullptr;
+    std::unique_ptr<tracy::VkCtxScope> m_TracyZone;
 };
 
 class VulkanTransferCommandBuffer final : public CopyCommandContext {
@@ -135,6 +138,7 @@ public:
     std::shared_ptr<vk::raii::Semaphore> swap_chain_image_available_semaphore;
     // get swapchain semaphore whose image whose layout transition to present
     std::pmr::vector<std::shared_ptr<vk::raii::Semaphore>> swap_chain_presentable_semaphores;
+    std::unique_ptr<tracy::VkCtxScope> m_TracyZone;
 };
 
 }  // namespace hitagi::gfx

--- a/hitagi/gfx/vulkan/vk_command_queue.cpp
+++ b/hitagi/gfx/vulkan/vk_command_queue.cpp
@@ -3,6 +3,7 @@ module;
 #include <fmt/color.h>
 #include <spdlog/logger.h>
 #include <vulkan/vulkan_raii.hpp>
+#include <tracy/TracyVulkan.hpp>
 
 module gfx.vulkan;
 import :command_queue;
@@ -17,6 +18,24 @@ VulkanCommandQueue::VulkanCommandQueue(VulkanDevice& device, CommandType type, s
 
 {
     create_vk_debug_object_info(m_Queue, m_Name, device.GetDevice());
+}
+
+VulkanCommandQueue::~VulkanCommandQueue() {
+    TracyVkDestroy(m_TracyCtx);
+}
+
+void VulkanCommandQueue::InitializeTracyContext() {
+    auto& device = static_cast<VulkanDevice&>(m_Device);
+    auto  setup_command_buffer = std::move(vk::raii::CommandBuffers(
+        device.GetDevice(),
+        vk::CommandBufferAllocateInfo{
+            .commandPool        = *device.GetCommandPool(m_Type),
+            .level              = vk::CommandBufferLevel::ePrimary,
+            .commandBufferCount = 1,
+        }).front());
+
+    m_TracyCtx = TracyVkContext(*device.GetPhysicalDevice(), *device.GetDevice(), *m_Queue, *setup_command_buffer);
+    TracyVkContextName(m_TracyCtx, m_Name.data(), static_cast<uint16_t>(m_Name.size()));
 }
 
 void VulkanCommandQueue::Submit(std::span<const std::reference_wrapper<const CommandContext>> contexts,

--- a/hitagi/gfx/vulkan/vk_command_queue.cppm
+++ b/hitagi/gfx/vulkan/vk_command_queue.cppm
@@ -1,6 +1,7 @@
 module;
 
 #include <vulkan/vulkan_raii.hpp>
+#include <tracy/TracyVulkan.hpp>
 export module gfx.vulkan:command_queue;
 import gfx.base;
 import :resource;
@@ -12,7 +13,7 @@ class VulkanDevice;
 class VulkanCommandQueue final : public CommandQueue {
 public:
     VulkanCommandQueue(VulkanDevice& device, CommandType type, std::string_view name, std::uint32_t queue_family_index);
-    ~VulkanCommandQueue() final = default;
+    ~VulkanCommandQueue() final;
 
     void Submit(
         std::span<const std::reference_wrapper<const CommandContext>> commands,
@@ -20,13 +21,16 @@ public:
         std::span<const FenceSignalInfo>                              signal_fences = {}) final;
 
     void WaitIdle() final;
+    void InitializeTracyContext();
 
     inline auto  GetFamilyIndex() const noexcept { return m_FamilyIndex; }
     inline auto& GetVkQueue() const noexcept { return m_Queue; }
+    inline auto  GetTracyCtx() const noexcept { return m_TracyCtx; }
 
 private:
     std::uint32_t   m_FamilyIndex;
     vk::raii::Queue m_Queue;
+    TracyVkCtx      m_TracyCtx = nullptr;
 };
 
 }  // namespace hitagi::gfx

--- a/hitagi/gfx/vulkan/vk_device.cpp
+++ b/hitagi/gfx/vulkan/vk_device.cpp
@@ -159,6 +159,10 @@ VulkanDevice::VulkanDevice(std::string_view name)
                 command_pool_create_info,
                 GetCustomAllocator());
         });
+
+        for (const auto& queue : m_CommandQueues) {
+            queue->InitializeTracyContext();
+        }
     }
 
     m_Logger->trace("Create Bindless...");
@@ -180,6 +184,7 @@ void VulkanDevice::Tick() {
 }
 
 void VulkanDevice::WaitIdle() {
+    ZoneScopedNS("VulkanDevice::WaitIdle", 8);
     m_Device->waitIdle();
 }
 

--- a/hitagi/gfx/vulkan/vk_sync.cpp
+++ b/hitagi/gfx/vulkan/vk_sync.cpp
@@ -1,4 +1,5 @@
 module;
+#include <tracy/Tracy.hpp>
 #include <vulkan/vulkan_raii.hpp>
 
 module gfx.vulkan;
@@ -36,6 +37,7 @@ void VulkanTimelineSemaphore::Signal(std::uint64_t value) {
 }
 
 bool VulkanTimelineSemaphore::Wait(std::uint64_t value, std::chrono::milliseconds timeout) {
+    ZoneScopedNS("VulkanTimelineSemaphore::Wait", 8);
     return static_cast<VulkanDevice&>(m_Device).GetDevice().waitSemaphores(
                vk::SemaphoreWaitInfo{
                    .semaphoreCount = 1,

--- a/hitagi/render/forward_renderer.cpp
+++ b/hitagi/render/forward_renderer.cpp
@@ -2,7 +2,7 @@ module;
 
 #include <imgui.h>
 #include <range/v3/all.hpp>
-#include <spdlog/logger.h>
+#include <spdlog/spdlog.h>
 #include <tracy/Tracy.hpp>
 
 #undef near
@@ -185,14 +185,20 @@ void ForwardRenderer::RenderScene(std::shared_ptr<asset::Scene> scene, const ass
                 };
 
                 for (auto [texture_bindless, texture_handle] : ranges::views::zip(bindless_infos[draw_index].textures, material_instance_info.textures)) {
-                    texture_bindless = pass.GetBindless(texture_handle);
+                    if (texture_handle) {
+                        texture_bindless = pass.GetBindless(texture_handle);
+                    }
                 }
 
                 cmd.PushBindlessMetaInfo({
                     .handle = pass.GetBindless(m_BindlessInfoConstantBuffer, draw_index),
                 });
                 for (const auto& vertex_attr : pipeline.GetDesc().vertex_input_layout) {
-                    cmd.SetVertexBuffers(vertex_attr.binding, {{pass.Resolve(mesh_info.vertices.at(vertex_attr.binding))}}, {{0}});
+                    auto mesh_attr   = asset::semantic_to_vertex_attribute(vertex_attr.semantic);
+                    auto attr_handle = mesh_info.vertices[mesh_attr];
+                    if (attr_handle) {
+                        cmd.SetVertexBuffers(vertex_attr.binding, {{pass.Resolve(attr_handle)}}, {{0}});
+                    }
                 }
                 cmd.SetIndexBuffer(pass.Resolve(mesh_info.indices), 0);
 
@@ -217,6 +223,11 @@ void ForwardRenderer::ToSwapChain(rg::TextureHandle from) {
 }
 
 void ForwardRenderer::RecordMaterialInstance(rg::RenderPassBuilder& builder, const std::shared_ptr<asset::MaterialInstance>& material_instance) {
+    if (!material_instance) return;
+    if (!material_instance->GetMaterial()) {
+        spdlog::warn("Material instance '{}' has no material assigned, skipping", material_instance->GetName());
+        return;
+    }
     if (m_MaterialInstanceInfos.contains(material_instance.get())) return;
 
     MaterialInstanceInfo info{
@@ -224,12 +235,24 @@ void ForwardRenderer::RecordMaterialInstance(rg::RenderPassBuilder& builder, con
         .samplers          = {m_Sampler},
     };
 
-    for (const auto& texture : material_instance->GetAssociatedTextures()) {
-        texture->InitGPUData(m_GfxDevice);
-        builder.Read(
-            info.textures.emplace_back(m_RenderGraph.Import(texture->GetGPUData(), texture->GetUniqueName())),
-            {},
-            gfx::PipelineStage::PixelShader);
+    auto associated = material_instance->GetAssociatedTextures();
+    if (associated.empty() && material_instance->GetMaterial()) {
+        spdlog::info("  '{}' (mat='{}') has 0 associated textures", material_instance->GetName(), material_instance->GetMaterial()->GetName());
+    }
+    for (std::size_t ti = 0; ti < associated.size(); ti++) {
+        const auto& texture = associated[ti];
+        if (texture && !texture->Empty()) {
+            texture->InitGPUData(m_GfxDevice);
+            builder.Read(
+                info.textures.emplace_back(m_RenderGraph.Import(texture->GetGPUData(), texture->GetUniqueName())),
+                {},
+                gfx::PipelineStage::PixelShader);
+        } else {
+            if (m_InstanceInfos.size() <= 1) {
+                spdlog::info("  '{}' texture[{}] = {}", material_instance->GetName(), ti, texture ? "empty" : "null");
+            }
+            info.textures.emplace_back(rg::TextureHandle{});
+        }
     }
 
     m_MaterialInstanceInfos.emplace(material_instance.get(), std::move(info));

--- a/hitagi/render/forward_renderer.cpp
+++ b/hitagi/render/forward_renderer.cpp
@@ -32,6 +32,8 @@ ForwardRenderer::ForwardRenderer(gfx::Device& device, const Application& app, gu
 }
 
 void ForwardRenderer::Tick() {
+    ZoneScopedN("RenderFrame");
+
     if (m_App.WindowSizeChanged()) {
         m_SwapChain->Resize();
     }
@@ -49,6 +51,13 @@ void ForwardRenderer::Tick() {
     m_SwapChain->Present();
 
     m_Clock.Tick();
+
+    static bool tracy_plot_configured = false;
+    if (!tracy_plot_configured) {
+        TracyPlotConfig("Render Frame Time (ms)", tracy::PlotFormatType::Number, false, true, 0);
+        tracy_plot_configured = true;
+    }
+    TracyPlot("Render Frame Time (ms)", m_Clock.DeltaTime().count() * 1000.0);
 }
 
 void ForwardRenderer::RenderScene(std::shared_ptr<asset::Scene> scene, const asset::Camera& camera, math::mat4f camera_transform, rg::TextureHandle target) {

--- a/xmake.lua
+++ b/xmake.lua
@@ -61,7 +61,6 @@ add_requires(
 add_requires("magic_enum", {configs = {modules = true}})
 add_requires("tracy v0.12.1")
 add_requires("assimp", {configs = {cxflags = "/EHsc"}})
-add_requires("usd", {configs = {toolchains = "msvc"}})
 add_requires("spdlog", {configs = {fmt_external = true}})
 add_requires("imgui v1.92.1-docking", {configs = {freetype = true, wchar32 = true}})
 add_requires("d3d12-memory-allocator", "directx12-agility-sdk", {optional = true})

--- a/xmake.lua
+++ b/xmake.lua
@@ -32,7 +32,7 @@ option_end()
 
 if has_config("profile") then
     add_defines("TRACY_ENABLE")
-    add_requireconfs("tracy", {configs = {on_demand = true}})
+    -- add_requireconfs("tracy", {configs = {on_demand = true}})
     if is_plat("windows") then
         add_defines("TRACY_IMPORTS")
     end


### PR DESCRIPTION
## Summary
- integrate Tracy CPU and GPU instrumentation across the engine, ECS scheduler, and DX12/Vulkan backends
- add profiling coverage for worker threads, render graph execution, frame timing, lock contention, and fence waits
- fix Tracy integration issues uncovered during testing, including DX12 GPU frame rollover and invalid bindless memory events

## Testing
- xmake build editor