### PR TITLE
[codex] Fix Windows clang CI build

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      CCACHE_DISABLE: "1"
+      SCCACHE_DISABLE: "1"
 
     strategy:
       matrix:
@@ -36,9 +39,32 @@ jobs:
           xmake-version: latest
           actions-cache-folder: ".xmake-cache"
 
+      - name: Disable compiler cache
+        run: |
+          $filteredPathEntries = foreach ($entry in ($env:Path -split ';')) {
+            if ([string]::IsNullOrWhiteSpace($entry)) {
+              continue
+            }
+
+            $pathEntry = $entry.Trim('"')
+            $hasCompilerCache = (Test-Path (Join-Path $pathEntry 'ccache.exe')) -or (Test-Path (Join-Path $pathEntry 'sccache.exe'))
+            if (-not $hasCompilerCache) {
+              $entry
+            }
+          }
+          $env:Path = $filteredPathEntries -join ';'
+          "Path=$env:Path" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          if (Get-Command ccache -ErrorAction SilentlyContinue) {
+            throw "ccache is still on PATH"
+          }
+          if (Get-Command sccache -ErrorAction SilentlyContinue) {
+            throw "sccache is still on PATH"
+          }
+          xmake g --ccache=n
+
       - name: Config
         run: |
-          xmake f -y -a x64 -m release ${{ matrix.compiler }}
+          xmake f -y -a x64 -m release ${{ matrix.compiler }} --ccache=n --policies=package.build.ccache:n,build.ccache:n
 
       - name: Build
         run: |

--- a/examples/playground/main.cpp
+++ b/examples/playground/main.cpp
@@ -1,5 +1,7 @@
 #include <spdlog/spdlog.h>
 #include <imgui.h>
+#include <combaseapi.h>
+#include <filesystem>
 #include <shlobj.h>
 
 import engine;
@@ -7,33 +9,45 @@ import asset;
 
 using namespace hitagi;
 
-static auto GetLatestWinPixGpuCapturerPath_Cpp17() {
+static auto GetLatestWinPixGpuCapturerPath_Cpp17() -> std::filesystem::path {
     LPWSTR programFilesPath = nullptr;
-    SHGetKnownFolderPath(FOLDERID_ProgramFiles, KF_FLAG_DEFAULT, nullptr, &programFilesPath);
+    if (FAILED(SHGetKnownFolderPath(FOLDERID_ProgramFiles, KF_FLAG_DEFAULT, nullptr, &programFilesPath)) ||
+        programFilesPath == nullptr) {
+        return {};
+    }
 
     std::filesystem::path pixInstallationPath = programFilesPath;
-    pixInstallationPath /= "Microsoft PIX";
+    CoTaskMemFree(programFilesPath);
 
-    std::string newestVersionFound;
+    pixInstallationPath /= "Microsoft PIX";
+    if (!std::filesystem::exists(pixInstallationPath)) {
+        return {};
+    }
+
+    std::wstring newestVersionFound;
 
     for (auto const& directory_entry : std::filesystem::directory_iterator(pixInstallationPath)) {
         if (directory_entry.is_directory()) {
-            if (newestVersionFound.empty() || newestVersionFound < directory_entry.path().filename().string()) {
-                newestVersionFound = directory_entry.path().filename().string();
+            const auto version = directory_entry.path().filename().wstring();
+            if (newestVersionFound.empty() || newestVersionFound < version) {
+                newestVersionFound = version;
             }
         }
     }
 
     if (newestVersionFound.empty()) {
-        // TODO: Error, no PIX installation found
+        return {};
     }
 
     return pixInstallationPath / newestVersionFound / L"WinPixGpuCapturer.dll";
 }
 
 auto main(int argc, char** argv) -> int {
-    if (GetModuleHandle("WinPixGpuCapturer.dll") == nullptr) {
-        LoadLibrary(GetLatestWinPixGpuCapturerPath_Cpp17().string().c_str());
+    if (GetModuleHandleW(L"WinPixGpuCapturer.dll") == nullptr) {
+        const auto pixCapturerPath = GetLatestWinPixGpuCapturerPath_Cpp17();
+        if (!pixCapturerPath.empty()) {
+            LoadLibraryW(pixCapturerPath.c_str());
+        }
     }
 
     spdlog::set_level(spdlog::level::trace);


### PR DESCRIPTION
## Summary

- Disable ccache/sccache for the Windows clang-cl GitHub Actions job, including the dependency-install phase.
- Keep the Windows workflow on clang-cl only while MSVC remains disabled.
- Fix the playground WinPIX loader to use wide-character Windows APIs when `UNICODE` is defined.

## Root cause

The latest `windows-build` run first failed before project compilation while xmake installed `assimp v6.0.4`. On `windows-latest`, `ccache.exe` from Strawberry Perl wrapped CMake's `cmcldeps` resource-compiler invocation and caused the RC `/fo` argument to be interpreted by `clang-cl`, ending with `clang-cl: error: no such file or directory: '/fo'`.

After disabling compiler cache launchers, PR CI progressed into the project build and exposed a real clang-cl compile error in `examples/playground/main.cpp`: with `UNICODE` enabled, `GetModuleHandle` and `LoadLibrary` resolve to the `W` variants but were passed narrow strings.

## Validation

- `xmake f -y -a x64 -m release --toolchain=clang-cl --ccache=n --policies=package.build.ccache:n,build.ccache:n`
- `xmake build playground`
- `xmake build`

This PR is draft so PR CI can validate the GitHub runner path before merging.
